### PR TITLE
Update webpack.config.js

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -592,7 +592,12 @@ module.exports = function (webpackEnv) {
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpacks internal loaders.
-              exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx|mdx)$/, /\.html$/, /\.json$/],
+              exclude: [
+                /^$/,
+                /\.(js|mjs|jsx|ts|tsx|md|mdx)$/,
+                /\.html$/,
+                /\.json$/,
+              ],
               type: 'asset/resource',
             },
             // ** STOP ** Are you adding a new loader?

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -592,7 +592,7 @@ module.exports = function (webpackEnv) {
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpacks internal loaders.
-              exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+              exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx|mdx)$/, /\.html$/, /\.json$/],
               type: 'asset/resource',
             },
             // ** STOP ** Are you adding a new loader?


### PR DESCRIPTION
Adds mdx to file loader exclude section

Addresses this issue: https://github.com/facebook/create-react-app/issues/12166

Just edits one line in the webpack config from react-scripts as suggested here:
https://github.com/mdx-js/mdx/discussions/1870#discussioncomment-2304871

I made the edit in my local version of `webpack.config.js` in `react-scripts` which is installed in my project, and that is sufficient to get mdx to work with no errors.
<img width="670" alt="Screen Shot 2022-03-14 at 12 04 13 PM" src="https://user-images.githubusercontent.com/2752623/158213344-909b0559-8ccd-4ce2-b993-f46985210665.png">



I don't know what other ramifications this might have. I'm not a JS dev, but this solution worked for my problem.
